### PR TITLE
feat: adds date validator (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,5 @@ TextFormField(
  Validatorless.number(String)
  Validatorless.cpf(String) 
  Validatorless.cnpj(String) 
+ Validatorless.date(String) 
 ```

--- a/lib/validatorless.dart
+++ b/lib/validatorless.dart
@@ -91,4 +91,14 @@ class Validatorless {
       return null;
     };
   }
+
+  static FormFieldValidator<String> date(String errorMessage) {
+    return (value) {
+      final date = DateTime.tryParse(value ?? '');
+      if (date == null) {
+        return errorMessage;
+      }
+      return null;
+    };
+  }
 }

--- a/lib/validatorless.dart
+++ b/lib/validatorless.dart
@@ -92,6 +92,9 @@ class Validatorless {
     };
   }
 
+  /// Validates if the field has a valid date according to `DateTime.tryParse`
+  /// 
+  /// e.g.: Validatorless.date('invalid date')
   static FormFieldValidator<String> date(String errorMessage) {
     return (value) {
       final date = DateTime.tryParse(value ?? '');

--- a/test/Validatorless_test.dart
+++ b/test/Validatorless_test.dart
@@ -6,4 +6,28 @@ void main() {
   test('validate values', () {
     Validatorless.required('');
   });
+
+  group('date', () {
+    test('accepts ISO 8601 formatted dates', () {
+      final validator = Validatorless.date('invalid date');
+      expect(validator("2012-02-27"), isNull);
+      expect(validator("2012-02-27 13:27:00"), isNull);
+      expect(validator("2012-02-27 13:27:00.123456789z"), isNull);
+      expect(validator("2012-02-27 13:27:00,123456789z"), isNull);
+      expect(validator("20120227 13:27:00"), isNull);
+      expect(validator("20120227T132700"), isNull);
+      expect(validator("20120227"), isNull);
+      expect(validator("+20120227"), isNull);
+      expect(validator("2012-02-27T14Z"), isNull);
+      expect(validator("2012-02-27T14+00:00"), isNull);
+      expect(validator("-123450101 00:00:00 Z"), isNull);
+      expect(validator("2002-02-27T14:00:00-0500"), isNull);
+    });
+
+    test('rejects dates othen than ISO dates', () {
+      final validator = Validatorless.date('invalid date');
+      expect(validator("27/02/2012"), isNotNull);
+      expect(validator("2012/02/27"), isNotNull);
+    });
+  });
 }


### PR DESCRIPTION
**Example of usage:**
```dart
Validatorless.date('invalid date');
```