### PR TITLE
Validate CPF or CNPJ together according to length

### DIFF
--- a/lib/validatorless.dart
+++ b/lib/validatorless.dart
@@ -119,6 +119,29 @@ class Validatorless {
   }
 
   /// ```dart
+  ///  Validatorless.cpfOrCnpj('This CPF is not valid', 'This CNPJ is not valid')
+  /// ```
+  static FormFieldValidator<String> cpfOrCnpj(String mCpf, String mCnpj) {
+    return (v) {
+      if (v?.isEmpty ?? true) return null;
+
+      final strippedValue = CnpjValidator.strip(v!);
+
+      if(strippedValue.length <= 11) {
+        if (CpfValidator.isValid(v!))
+          return null;
+        else
+          return mCpf;
+      } else {
+          if (CNPJValidator.isValid(v!))
+            return null;
+          else
+            return mCnpj;
+      }
+    };
+  }
+
+  /// ```dart
   ///  Validatorless.cpf('This CPF is not valid')
   /// ```
   static FormFieldValidator<String> cpf(String m) {

--- a/lib/validatorless.dart
+++ b/lib/validatorless.dart
@@ -125,9 +125,10 @@ class Validatorless {
     return (v) {
       if (v?.isEmpty ?? true) return null;
 
+      const int cpfMaxLength = 11;
       final strippedValue = CNPJValidator.strip(v!);
 
-      if(strippedValue.length <= 11) {
+      if(strippedValue.length <= cpfMaxLength) {
         if (CpfValidator.isValid(v!))
           return null;
         else

--- a/lib/validatorless.dart
+++ b/lib/validatorless.dart
@@ -125,7 +125,7 @@ class Validatorless {
     return (v) {
       if (v?.isEmpty ?? true) return null;
 
-      final strippedValue = CnpjValidator.strip(v!);
+      final strippedValue = CNPJValidator.strip(v!);
 
       if(strippedValue.length <= 11) {
         if (CpfValidator.isValid(v!))


### PR DESCRIPTION
I have a field that I use the brasil_fields formatter called "CpfOuCnpjFormatter" which, according to the number of characters typed, the formatter is changed between CPF and CNPJ.